### PR TITLE
do not require ansible to be installed

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,18 +56,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["modifyvm", :id, "--memory", "2048"]
   end
 
-  if OS.windows?
-      config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
-      config.vm.provision :shell, path: "provisioning/windows.sh",
-                          :keep_color => true
-
-  else
-    config.vm.provision "ansible" do |ansible|
-      ansible.playbook = "provisioning/vagrant.yml"
-      # output as much as you can, or comment this out for silence
-      ansible.verbose = "vvvv"
-      ansible.sudo = true
-    end
-  end
+  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
+  config.vm.provision :shell, path: "provisioning/windows.sh",
+                      :keep_color => true
 
 end


### PR DESCRIPTION
this would simplify the setup for apple/linux users that don't have ansible.

if this would be ok, i can adjust the README and the naming
